### PR TITLE
fix: 修复 data-table  在 onRowSelectionChange 中设置状态时，出现无限循环报错

### DIFF
--- a/registry/components/data-table/index.stories.tsx
+++ b/registry/components/data-table/index.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 
-import { DataTable } from "./index";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
+
+import { DataTable } from "./index";
 
 const meta = {
   title: "Components/Data Table",

--- a/registry/components/data-table/index.tsx
+++ b/registry/components/data-table/index.tsx
@@ -1,13 +1,5 @@
 "use client";
 
-import {
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
-import { ButtonGroup } from "@/components/ui/button-group";
-import { useEffect, useMemo, useState } from "react";
-import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
 import type {
   Column,
   ColumnDef,
@@ -15,8 +7,25 @@ import type {
   RowSelectionState,
   TableOptions,
 } from "@tanstack/react-table";
-
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
 import type { CSSProperties, ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Table,
   TableBody,
@@ -25,15 +34,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
 function getCommonPinningStyles<TData>(column: Column<TData>): CSSProperties {
@@ -127,17 +127,26 @@ export function DataTable<TData extends RowData, TValue = unknown>({
         : []),
       ...columns,
     ];
-  }, [columns]);
+  }, [columns, !!onRowSelectionChange]);
 
   const tableColumns: Array<ColumnDef<TData, TValue>> = useMemo(() => {
     return columnsWithSelection.map((column) => ({
       accessorKey: column.id,
       ...column,
     }));
-  }, [columnsWithSelection, onRowSelectionChange]);
+  }, [columnsWithSelection]);
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [isAllPageRowsSelected, setIsAllPageRowsSelected] = useState(false);
+
+  // 使用 useRef 存储外部回调，避免在 useEffect 依赖中引用导致无限循环
+  const onRowSelectionChangeRef = useRef(onRowSelectionChange);
+  const onAllRowsSelectedChangeRef = useRef(onAllRowsSelectedChange);
+
+  useEffect(() => {
+    onRowSelectionChangeRef.current = onRowSelectionChange;
+    onAllRowsSelectedChangeRef.current = onAllRowsSelectedChange;
+  }, [onRowSelectionChange, onAllRowsSelectedChange]);
 
   const table = useReactTable<TData>({
     data,
@@ -159,18 +168,17 @@ export function DataTable<TData extends RowData, TValue = unknown>({
   });
 
   useEffect(() => {
-    onRowSelectionChange?.(
+    // 调用行选择变化回调
+    onRowSelectionChangeRef.current?.(
       table.getSelectedRowModel().rows.map((row) => row.original),
     );
+  }, [rowSelection, data.length]);
 
-    if (table.getSelectedRowModel().rows.length !== table.getRowCount()) {
-      setIsAllPageRowsSelected(false);
-    }
-  }, [onRowSelectionChange, table.getSelectedRowModel().rows]);
-
-  useEffect(() => {
-    onAllRowsSelectedChange?.(isAllPageRowsSelected);
-  }, [isAllPageRowsSelected, onAllRowsSelectedChange]);
+  // 处理全选操作
+  const handleAllRowsSelectedChange = useCallback((selected: boolean) => {
+    setIsAllPageRowsSelected(selected);
+    onAllRowsSelectedChangeRef.current?.(selected);
+  }, []);
 
   return (
     <div>
@@ -211,7 +219,7 @@ export function DataTable<TData extends RowData, TValue = unknown>({
                     <DropdownMenuItem
                       onClick={() => {
                         table.toggleAllPageRowsSelected(true);
-                        setIsAllPageRowsSelected(true);
+                        handleAllRowsSelectedChange(true);
                       }}
                     >
                       Select all
@@ -219,7 +227,10 @@ export function DataTable<TData extends RowData, TValue = unknown>({
                   )}
 
                   <DropdownMenuItem
-                    onClick={() => table.toggleAllPageRowsSelected(false)}
+                    onClick={() => {
+                      table.toggleAllPageRowsSelected(false);
+                      handleAllRowsSelectedChange(false);
+                    }}
                   >
                     Unselect all
                   </DropdownMenuItem>

--- a/registry/components/data-table/index.tsx
+++ b/registry/components/data-table/index.tsx
@@ -172,7 +172,8 @@ export function DataTable<TData extends RowData, TValue = unknown>({
     onRowSelectionChangeRef.current?.(
       table.getSelectedRowModel().rows.map((row) => row.original),
     );
-  }, [rowSelection, data.length]);
+    // 如果行选择发生变化，则更新全选状态，另外如果数据长度发生变化，如删除某行，则更新全选状态，内部用了 table，所以依赖了 table
+  }, [rowSelection, data.length, table]);
 
   // 处理全选操作
   const handleAllRowsSelectedChange = useCallback((selected: boolean) => {
@@ -299,7 +300,7 @@ export function DataTable<TData extends RowData, TValue = unknown>({
             ) : (
               <TableRow>
                 <TableCell
-                  colSpan={columns.length}
+                  colSpan={tableColumns.length}
                   className="bg-background h-24 text-center"
                 >
                   No results.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Data table selection logic reorganized to keep internal selection state and external callbacks synchronized. "Select all"/"Unselect all" actions now consistently update internal state and notify external listeners without changing the public API.

* **Style**
  * Cleaned up story imports and formatting for readability; no runtime behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->